### PR TITLE
Add support for mappable commands (and introduce a picker for all commands, showing their binding)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 
 **/.bamboost*/
 **/out*/
+bamboost.toml

--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
 # Bamboost terminal interface
 
 Complementary TUI for [bamboost](https://gitlab.com/cmbm-ethz/bamboost).
+
+## Key bindings
+
+To override key bindings, specify them in the bamboost config file like this:
+
+> [!note]
+> Below we maintain a list all modifieable bindings (they need to have an "id" assigned).
+
+```toml
+[tui.keys]
+"app.command_palette" = "ctrl+p"
+"app.help" = "question_mark"
+
+"collection.toggle_picker" = "ctrl+m,p"
+"collection.cycle_tabs" = "t"
+"collection.sync" = "c>s"
+
+"index.scan" = "alt+ctrl+s"
+"index.clean" = "alt+ctrl+j"
+```

--- a/bamboost_tui/app.py
+++ b/bamboost_tui/app.py
@@ -1,16 +1,21 @@
 # pyright: reportUnusedImport=false
 from __future__ import annotations
 
+from typing import Any, Mapping
+
+from bamboost import config
 from textual import work
 from textual.app import App
 from textual.binding import Binding
 from textual.css.query import NoMatches
 from textual.widgets import HelpPanel
 
-from bamboost_tui.screens.collection import ScreenCollection
 from bamboost_tui.command_palette import CommandPalette
-from bamboost_tui.command_registry import command_registry
+from bamboost_tui.screens.collection import ScreenCollection
 from bamboost_tui.theme import ANSI_THEME
+from bamboost_tui.utils import get_index
+
+config_tui: Mapping[str, Any] = config._remainder.get("tui", {})
 
 
 class BamboostApp(App):
@@ -20,25 +25,31 @@ class BamboostApp(App):
         Binding("ctrl+z", "suspend_process", "suspend application", show=False),
         Binding("q", "pop_screen_or_exit", "quit screen"),
         Binding("Q", "quit", "exit"),
-        Binding("?", "toggle_help_panel", "Show help"),
-        Binding("ctrl+o", "command_palette", "Command palette"),
+        Binding("?", "toggle_help_panel", "Show help", id="app.help"),
+        Binding(
+            "ctrl+p", "command_palette", "Command palette", id="app.command_palette"
+        ),
+        Binding(
+            "alt+ctrl+j",
+            "clean_index",
+            "Clean the collection database",
+            id="index.clean",
+            system=True,
+        ),
+        Binding(
+            "alt+ctrl+s",
+            "scan_collections",
+            "Scan for collections",
+            id="index.scan",
+            system=True,
+        ),
     ]
     ENABLE_COMMAND_PALETTE = False
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-        # bind the keys from the command_registry
-
-        for cmd in command_registry:
-            if cmd.key:
-
-                def _action_func(self=self, cmd=cmd) -> None:
-                    return cmd.func(self)
-
-                func_name = cmd.name.replace(".", "_")
-                self.__setattr__(f"action_{func_name}", _action_func)
-                self.bind(cmd.key, func_name, description=cmd.label, show=False)
+        # set the keymap from the config
+        self.set_keymap(config_tui.get("keys", {}))
 
     def on_mount(self) -> None:
         if ansi_colors_set := self.ansi_color:
@@ -79,6 +90,15 @@ class BamboostApp(App):
 
     def action_command_palette(self) -> None:
         self.push_screen(CommandPalette())
+
+    def action_scan_collections(self) -> None:
+        """Scan for collections."""
+        get_index().scan_for_collections()
+        self.notify("✔️ Scanned for collections")
+
+    def action_clean_index(self) -> None:
+        get_index().check_integrity()
+        self.notify("⚪ Cleaned index")
 
 
 if __name__ == "__main__":

--- a/bamboost_tui/app.py
+++ b/bamboost_tui/app.py
@@ -5,37 +5,12 @@ from textual import work
 from textual.app import App
 from textual.binding import Binding
 from textual.css.query import NoMatches
-from textual.theme import BUILTIN_THEMES, Theme
 from textual.widgets import HelpPanel
 
 from bamboost_tui.screens.collection import ScreenCollection
-from bamboost_tui.screens.command_palette import CommandPalette
-
-ansi_theme = Theme(
-    name="ansi",
-    primary="ansi_blue",
-    secondary="ansi_magenta",
-    accent="ansi_yellow",
-    foreground="ansi_bright_white",
-    background="ansi_default",
-    success="ansi_bright_green",
-    warning=BUILTIN_THEMES["textual-dark"].warning,
-    error="ansi_red",
-    surface="ansi_black",
-    panel="ansi_bright_black",
-    boost="ansi_bright_green",
-    dark=True,
-    variables={
-        "foreground-muted": "ansi_white",
-        "input-cursor-background": "ansi_black",
-        "input-cursor-foreground": "ansi_white",
-        "block-cursor-background": "ansi_black",
-        "block-cursor-foreground": "ansi_white",
-        "border": "ansi_bright_black",
-        "border-focus": "ansi_blue",
-        "footer-background": "ansi_black",
-    },
-)
+from bamboost_tui.command_palette import CommandPalette
+from bamboost_tui.command_registry import command_registry
+from bamboost_tui.theme import ANSI_THEME
 
 
 class BamboostApp(App):
@@ -50,9 +25,24 @@ class BamboostApp(App):
     ]
     ENABLE_COMMAND_PALETTE = False
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # bind the keys from the command_registry
+
+        for cmd in command_registry:
+            if cmd.key:
+
+                def _action_func(self=self, cmd=cmd) -> None:
+                    return cmd.func(self)
+
+                func_name = cmd.name.replace(".", "_")
+                self.__setattr__(f"action_{func_name}", _action_func)
+                self.bind(cmd.key, func_name, description=cmd.label, show=False)
+
     def on_mount(self) -> None:
         if ansi_colors_set := self.ansi_color:
-            self.register_theme(ansi_theme)
+            self.register_theme(ANSI_THEME)
             self.theme = "ansi"
             self.ansi_color = ansi_colors_set
         else:
@@ -67,12 +57,12 @@ class BamboostApp(App):
     @work(thread=True)
     async def _preload_modules(self) -> None:
         # Import in a thread to avoid blocking the event loop
-        import bamboost.core.hdf5.attrsdict
-        import bamboost.core.hdf5.file
-        import bamboost.core.simulation
-        import bamboost.index
-        import h5py
-        import pandas
+        import bamboost.core.hdf5.attrsdict  # noqa: F401
+        import bamboost.core.hdf5.file  # noqa: F401
+        import bamboost.core.simulation  # noqa: F401
+        import bamboost.index  # noqa: F401
+        import h5py  # noqa: F401
+        import pandas  # noqa: F401
 
     async def action_toggle_help_panel(self):
         try:

--- a/bamboost_tui/app.py
+++ b/bamboost_tui/app.py
@@ -1,3 +1,4 @@
+# pyright: reportUnusedImport=false
 from __future__ import annotations
 
 from textual import work

--- a/bamboost_tui/app.py
+++ b/bamboost_tui/app.py
@@ -10,8 +10,8 @@ from textual.binding import Binding
 from textual.css.query import NoMatches
 from textual.widgets import HelpPanel
 
-from bamboost_tui.command_palette import CommandPalette
 from bamboost_tui.screens.collection import ScreenCollection
+from bamboost_tui.screens.keybind_palette import KeybindPalette
 from bamboost_tui.theme import ANSI_THEME
 from bamboost_tui.utils import get_index
 
@@ -27,7 +27,7 @@ class BamboostApp(App):
         Binding("Q", "quit", "exit"),
         Binding("?", "toggle_help_panel", "Show help", id="app.help"),
         Binding(
-            "ctrl+p", "command_palette", "Command palette", id="app.command_palette"
+            "ctrl+p", "command_palette", "Keybind picker", id="app.command_palette"
         ),
         Binding(
             "alt+ctrl+j",
@@ -35,6 +35,7 @@ class BamboostApp(App):
             "Clean the collection database",
             id="index.clean",
             system=True,
+            show=False,
         ),
         Binding(
             "alt+ctrl+s",
@@ -42,6 +43,7 @@ class BamboostApp(App):
             "Scan for collections",
             id="index.scan",
             system=True,
+            show=False,
         ),
     ]
     ENABLE_COMMAND_PALETTE = False
@@ -89,7 +91,7 @@ class BamboostApp(App):
             self.exit()
 
     def action_command_palette(self) -> None:
-        self.push_screen(CommandPalette())
+        self.push_screen(KeybindPalette())
 
     def action_scan_collections(self) -> None:
         """Scan for collections."""

--- a/bamboost_tui/bamboost.tcss
+++ b/bamboost_tui/bamboost.tcss
@@ -11,10 +11,12 @@ $background-cp: transparent;
 # TOAST
 # ---------------------------------------------
 Toast {
-    background: $surface;
-    padding: 0 1;
+    background: $background-cp;
+    border: round $border;
+    padding: 1 1;
     margin: 0;
 }
+
 Rule {
     margin: 0;
     color: $foreground;
@@ -172,7 +174,7 @@ LoadingIndicator {
 # DATATABLE
 # ---------------------------------------------
 CollectionTable {
-    background: $background;
+    background: $background-cp;
     scrollbar-size: 0 1;
 
     &:focus {
@@ -355,6 +357,11 @@ HDFViewer {
 # ---------------------------------------------
 CommandPalette {
   background: transparent;
+  & > .command-palette--highlight {
+    background: $accent;
+    color: $surface;
+    text-style: bold;
+  }
 
   &>Vertical {
     margin-top: 2;
@@ -458,6 +465,9 @@ CommandList {
 # -------------------------
 # PICKER
 # -------------------------
+CommandPalette  {
+}
+
 CollectionPicker {
     #--input {
         border: round $secondary;
@@ -513,5 +523,3 @@ ModalPrompt {
         background: $background;
     }
 }
-
-

--- a/bamboost_tui/bamboost.tcss
+++ b/bamboost_tui/bamboost.tcss
@@ -23,17 +23,13 @@ Rule {
 }
 
 Footer {
-    background: $surface;
+    background: $background;
     grid-gutter: 0;
-    padding-left: 1;
 
     & .footer-key--key {
-        background: $surface;
-        padding-right: 1;
         color: $accent;
     }
     & .footer-key--description {
-        background: $surface;
         color: $foreground-muted;
         opacity: 0.3;
     }
@@ -62,7 +58,7 @@ HelpPanel {
             background: ansi_default;
         }
     }
-  
+
     #title {
         width: 1fr;
         text-align: center;
@@ -70,7 +66,7 @@ HelpPanel {
         dock: top;
         display: none;
     }
-    
+
     #widget-help {
         height: auto;
         max-height: 50%;
@@ -102,7 +98,7 @@ HelpPanel {
         height: 1fr;
         min-width: initial;
         split: initial;
-        border-left: none;          
+        border-left: none;
         padding: 0;
         scrollbar-size-vertical: 1;
         scrollbar-background: $background;
@@ -119,7 +115,7 @@ BindingsTable > .bindings-table--header {
     color: $accent;
 }
 
-    
+
 
 
 # ---------------------------------------------
@@ -127,7 +123,13 @@ BindingsTable > .bindings-table--header {
 # ---------------------------------------------
 CommandLine {
     align: left bottom;
-    background: transparent;
+
+    & > Horizontal {
+        width: 100%;
+        align: center middle;
+        height: 1;
+        background: $background;
+    }
 
     & > Horizontal > Label {
         margin: 0 1;
@@ -138,7 +140,6 @@ CommandLineInput {
     padding: 0 0;
     background: transparent;
     height: 1;
-    width: 100%;
 }
 AutoComplete {
 }

--- a/bamboost_tui/command_palette.py
+++ b/bamboost_tui/command_palette.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -12,79 +10,40 @@ from textual.containers import Horizontal, Vertical
 from textual.system_commands import SystemCommandsProvider
 from textual.widgets import Button, LoadingIndicator
 
-from bamboost_tui.utils import get_index
-
-if TYPE_CHECKING:
-    pass
+from bamboost_tui.command_registry import command_registry, Command
 
 
-@dataclass
-class CustomCommand:
-    name: str
-    command: Callable[[GlobalCommands], Any]
-    label: str
-    help: Optional[str] = None
-
-
-_commands: list[CustomCommand] = []
-
-
-def _add_command(name: str, label: str, help: Optional[str] = None) -> Callable:
-    """Decorator to add a command to the command palette."""
-
-    def decorator(method: Callable) -> Callable:
-        _commands.append(CustomCommand(name, method, label, help))
-        return method
-
-    return decorator
-
-
-class GlobalCommands(Provider):
+class AppCommands(Provider):
     """A command provider for the command palette."""
 
-    COMMANDS: list[CustomCommand] = _commands
+    def get_commands(self) -> list[Command]:
+        return command_registry
 
     async def startup(self) -> None:
         """Called once when the command palette is opened, prior to searching."""
         pass
-        # self.COMMANDS = [
-        #     CustomCommand(
-        #         "Scan for collections",
-        #         self.scan_collections,
-        #         "The config is based on the current working directory.",
-        #     ),
-        # ]
 
     async def search(self, query: str) -> Hits:
         matcher = self.matcher(query)
-        for cmd in self.COMMANDS:
-            score = matcher.match(cmd.name)
+        for cmd in self.get_commands():
+            score = matcher.match(cmd.label)
             if score > 0:
                 yield Hit(
                     score,
-                    matcher.highlight(cmd.name),
-                    lambda: cmd.command(self),
-                    help=cmd.help,
+                    matcher.highlight(cmd.label),
+                    lambda cmd=cmd: cmd.func(self.app),
+                    help=rf"{cmd.name} \[{cmd.key}] / {cmd.help}",
                 )
 
     async def discover(self) -> Hits:
         """Called when the command palette is opened, prior to searching."""
-        for cmd in self.COMMANDS:
+        for cmd in self.get_commands():
             yield DiscoveryHit(
-                cmd.name,
-                lambda: cmd.command(self),
-                help=cmd.help,
+                cmd.label,
+                lambda cmd=cmd: cmd.func(self.app),
+                text=cmd.label,
+                help=rf"{cmd.name} \[{cmd.key}] / {cmd.help}",
             )
-
-    @_add_command(
-        "scan_collections",
-        label="Scan for collections",
-        help="The config is based on the current working directory.",
-    )
-    def scan_collections(self) -> None:
-        """Scan for collections."""
-        get_index().scan_for_collections()
-        self.app.notify("✔️ Scanned for collections")
 
 
 class CommandPalette(BaseCommandPalette):
@@ -100,7 +59,7 @@ class CommandPalette(BaseCommandPalette):
 
     def __init__(self):
         super().__init__(
-            providers=[SystemCommandsProvider, GlobalCommands],
+            providers=[SystemCommandsProvider, AppCommands],
             placeholder="Search commands...",
         )
 

--- a/bamboost_tui/command_palette.py
+++ b/bamboost_tui/command_palette.py
@@ -1,49 +1,12 @@
 from __future__ import annotations
 
+from time import monotonic
 
-from textual.app import ComposeResult
+from textual import work
 from textual.binding import Binding
-from textual.command import CommandInput, CommandList
+from textual.command import Command, CommandList
 from textual.command import CommandPalette as BaseCommandPalette
-from textual.command import Hit, Hits, Provider, SearchIcon
-from textual.containers import Horizontal, Vertical
-from textual.screen import Screen
-from textual.system_commands import SystemCommandsProvider
-from textual.widgets import Button, LoadingIndicator
-
-
-class BindingsProvider(Provider):
-    """A command provider that exposes all Bindings from the app, screen, and widgets."""
-
-    def get_all_bindings(self, screen: Screen):
-        return screen.active_bindings.values()
-
-    async def search(self, query: str) -> Hits:
-        matcher = self.matcher(query)
-        screen = self.app.screen_stack[-2]
-        for active_binding in self.get_all_bindings(screen):
-            binding = active_binding.binding
-            score = matcher.match(
-                binding.description + binding.key + (binding.id or "")
-            )
-            if score > 0:
-                yield Hit(
-                    score,
-                    matcher.highlight(binding.description or binding.key),
-                    lambda b=binding: self.app.simulate_key(b.key),
-                    help=f"{binding.key} / {binding.description or binding.action}",
-                )
-
-    async def discover(self) -> Hits:
-        screen = self.app.screen_stack[-2]
-        for active_binding in self.get_all_bindings(screen):
-            binding = active_binding.binding
-            yield Hit(
-                1,
-                binding.description or binding.key,
-                lambda b=binding: self.app.simulate_key(b.key),
-                help=f"{binding.key} / {binding.description or binding.action}",
-            )
+from textual.worker import get_current_worker
 
 
 class CommandPalette(BaseCommandPalette):
@@ -51,31 +14,73 @@ class CommandPalette(BaseCommandPalette):
         Binding("ctrl+n", "cursor_down", "move cursor down", show=False),
         Binding("ctrl+p", "command_list('cursor_up')", "move cursor up", show=False),
     ]
-    COMPONENT_CLASSES = BaseCommandPalette.COMPONENT_CLASSES | {
-        "collection-list--uid",
-        "collection-list--path",
-        "collection-list--count",
-    }
 
-    def __init__(self):
-        super().__init__(
-            providers=[SystemCommandsProvider, BindingsProvider],
-            placeholder="Search commands...",
-        )
+    @work(exclusive=True, group=BaseCommandPalette._GATHER_COMMANDS_GROUP)
+    async def _gather_commands(self, search_value: str) -> None:
+        """Gather up all of the commands that match the search value.
 
-    def compose(self) -> ComposeResult:
-        """Compose the command palette.
-
-        Returns:
-            The content of the screen.
+        Args:
+            search_value: The value to search for.
         """
-        with Vertical(id="--container"):
-            with Horizontal(id="--input") as container:
-                container.border_title = "Command Palette"
-                yield SearchIcon()
-                yield CommandInput(placeholder=self._placeholder)
-                if not self.run_on_select:
-                    yield Button("\u25b6")
-            with Vertical(id="--results"):
-                yield CommandList()
-                yield LoadingIndicator()
+        gathered_commands: list[Command] = []
+        command_list = self.query_one(CommandList)
+        if (
+            command_list.option_count == 1
+            and command_list.get_option_at_index(0).id == self._NO_MATCHES
+        ):
+            command_list.remove_option(self._NO_MATCHES)
+
+        command_id = 0
+        worker = get_current_worker()
+
+        # Reset busy mode.
+        self._show_busy = False
+        clear_current = True
+        last_update = monotonic()
+
+        # Kick off the search, grabbing the iterator.
+        search_routine = self._search_for(search_value)
+        search_results = search_routine.__aiter__()
+
+        # We're going to be doing the send/await dance in this code, so we
+        # need to grab the first yielded command to start things off.
+        try:
+            hit = await search_results.__anext__()
+        except StopAsyncIteration:
+            hit = None
+
+        while hit:
+            # NEEDED TO CHANGE THIS LINE. RENDER THE PROMPT DIRECTLY
+            prompt = hit.prompt
+
+            gathered_commands.append(Command(prompt, hit, id=str(command_id)))
+
+            if worker.is_cancelled:
+                break
+
+            now = monotonic()
+            if (now - last_update) > self._RESULT_BATCH_TIME:
+                self._refresh_command_list(
+                    command_list, gathered_commands, clear_current
+                )
+                clear_current = False
+                last_update = now
+
+            command_id += 1
+
+            try:
+                hit = await search_routine.asend(worker.is_cancelled)
+            except StopAsyncIteration:
+                break
+
+        if not worker.is_cancelled:
+            self._refresh_command_list(command_list, gathered_commands, clear_current)
+
+        # One way or another, we're not busy any more.
+        self._show_busy = False
+
+        if command_list.option_count == 0 and not worker.is_cancelled:
+            self._hit_count = 0
+            self._start_no_matches_countdown(search_value)
+
+        self.add_class("-ready")

--- a/bamboost_tui/command_palette.py
+++ b/bamboost_tui/command_palette.py
@@ -5,44 +5,44 @@ from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.command import CommandInput, CommandList
 from textual.command import CommandPalette as BaseCommandPalette
-from textual.command import DiscoveryHit, Hit, Hits, Provider, SearchIcon
+from textual.command import Hit, Hits, Provider, SearchIcon
 from textual.containers import Horizontal, Vertical
+from textual.screen import Screen
 from textual.system_commands import SystemCommandsProvider
 from textual.widgets import Button, LoadingIndicator
 
-from bamboost_tui.command_registry import command_registry, Command
 
+class BindingsProvider(Provider):
+    """A command provider that exposes all Bindings from the app, screen, and widgets."""
 
-class AppCommands(Provider):
-    """A command provider for the command palette."""
-
-    def get_commands(self) -> list[Command]:
-        return command_registry
-
-    async def startup(self) -> None:
-        """Called once when the command palette is opened, prior to searching."""
-        pass
+    def get_all_bindings(self, screen: Screen):
+        return screen.active_bindings.values()
 
     async def search(self, query: str) -> Hits:
         matcher = self.matcher(query)
-        for cmd in self.get_commands():
-            score = matcher.match(cmd.label)
+        screen = self.app.screen_stack[-2]
+        for active_binding in self.get_all_bindings(screen):
+            binding = active_binding.binding
+            score = matcher.match(
+                binding.description + binding.key + (binding.id or "")
+            )
             if score > 0:
                 yield Hit(
                     score,
-                    matcher.highlight(cmd.label),
-                    lambda cmd=cmd: cmd.func(self.app),
-                    help=rf"{cmd.name} \[{cmd.key}] / {cmd.help}",
+                    matcher.highlight(binding.description or binding.key),
+                    lambda b=binding: self.app.simulate_key(b.key),
+                    help=f"{binding.key} / {binding.description or binding.action}",
                 )
 
     async def discover(self) -> Hits:
-        """Called when the command palette is opened, prior to searching."""
-        for cmd in self.get_commands():
-            yield DiscoveryHit(
-                cmd.label,
-                lambda cmd=cmd: cmd.func(self.app),
-                text=cmd.label,
-                help=rf"{cmd.name} \[{cmd.key}] / {cmd.help}",
+        screen = self.app.screen_stack[-2]
+        for active_binding in self.get_all_bindings(screen):
+            binding = active_binding.binding
+            yield Hit(
+                1,
+                binding.description or binding.key,
+                lambda b=binding: self.app.simulate_key(b.key),
+                help=f"{binding.key} / {binding.description or binding.action}",
             )
 
 
@@ -59,7 +59,7 @@ class CommandPalette(BaseCommandPalette):
 
     def __init__(self):
         super().__init__(
-            providers=[SystemCommandsProvider, AppCommands],
+            providers=[SystemCommandsProvider, BindingsProvider],
             placeholder="Search commands...",
         )
 

--- a/bamboost_tui/command_registry.py
+++ b/bamboost_tui/command_registry.py
@@ -1,0 +1,52 @@
+import sys
+from typing import Optional
+from typing import Callable
+from typing import List
+
+from textual.app import App
+from bamboost_tui.utils import get_index
+from dataclasses import dataclass
+from bamboost import config
+
+
+@dataclass
+class Command:
+    name: str
+    label: str
+    help: Optional[str]
+    key: Optional[str]
+    func: Callable
+
+
+command_registry: List[Command] = []
+
+
+def register_command(name, label, help=None, key=None):
+    def decorator(func):
+        command_registry.append(
+            Command(
+                name,
+                label,
+                help,
+                config._remainder.get("tui", {}).get("keys", {}).get(name, key),
+                func,
+            )
+        )
+        return func
+
+    return decorator
+
+
+@register_command("index.clean", label="Clean the collection index", key="ctrl+shift+i")
+def clean_index(app: App) -> None:
+    get_index().check_integrity()
+    app.notify("⚪ Cleaned index")
+
+
+@register_command(
+    "index.scan", label="Scan for collections", help="search", key="ctrl+s"
+)
+def scan_collections(app: App) -> None:
+    """Scan for collections."""
+    get_index().scan_for_collections()
+    app.notify("✔️ Scanned for collections")

--- a/bamboost_tui/commandline/base.py
+++ b/bamboost_tui/commandline/base.py
@@ -23,7 +23,8 @@ from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal
 from textual.message import Message
-from textual.screen import Screen
+from textual.screen import ModalScreen, Screen
+from textual.widget import Widget
 from textual.widgets import Input, Label
 from textual.widgets.data_table import ColumnKey
 from typing_extensions import Self
@@ -247,14 +248,14 @@ class Parser:
         return self._commands[args.command].set_parsed_values(args)
 
 
-class CommandLine(Screen):
+class CommandLine(ModalScreen[CommandMessage]):
     BINDINGS = [
         Binding("escape", "dismiss"),
         Binding("enter", "execute", "do this thing"),
     ]
     DEFAULT_CSS = """
     CommandLine {
-        background: transparent;
+        background: $background;
 
         & > Horizontal {
             width: 100%;
@@ -299,7 +300,7 @@ class CommandLine(Screen):
 
     def compose(self) -> ComposeResult:
         with Horizontal(id="command-line"):
-            yield Label(self.label)
+            yield Label(self.label, disabled=True)
             yield CommandLineInput(placeholder=self.placeholder)
 
     def on_mount(self) -> None:

--- a/bamboost_tui/screens/collection.py
+++ b/bamboost_tui/screens/collection.py
@@ -208,7 +208,9 @@ class CollectionTable(ModifiedDataTable, KeySubgroupsMixin, inherit_bindings=Fal
         Binding("d", "delete", "delete simulation", show=False),
         Binding("o>p", "open_paraview", "open paraview", show=False),
         Binding("o>d", "open_directory", "open directory in editor", show=False),
-        Binding("c>s", "sync", "sync collection with fs", show=False),
+        Binding(
+            "c>s", "sync", "sync collection with fs", show=False, id="collection.sync"
+        ),
     ]
     BINDING_GROUP_TITLE = "Collection commands"
     COMPONENT_CLASSES = DataTable.COMPONENT_CLASSES | {
@@ -434,22 +436,22 @@ class CollectionTable(ModifiedDataTable, KeySubgroupsMixin, inherit_bindings=Fal
 
 class ScreenCollection(Screen, inherit_bindings=False):
     BINDINGS = [
-        Binding("ctrl+m", "toggle_picker", "toggle the collection picker"),
+        Binding(
+            "ctrl+m",
+            "toggle_picker",
+            "toggle the collection picker",
+            id="collection.toggle_picker",
+        ),
         Binding(
             "ctrl+t",
             "cycle_tabs",
-            "cycle through tabs",
+            "cycle through collection tabs",
             show=False,
             id="collection.cycle_tabs",
         ),
         Binding("q", "close", "close collection", show=False),
     ]
     BINDING_GROUP_TITLE = "Screen commands"
-    DEFAULT_CSS = """
-    ScreenCollection {
-        layers: bottom top;
-    }
-    """
 
     _open_collections: dict[str, CollectionTable]
     current_uid: var[str | None] = var(None)

--- a/bamboost_tui/screens/collection.py
+++ b/bamboost_tui/screens/collection.py
@@ -25,7 +25,7 @@ from typing_extensions import Self
 
 from bamboost_tui.commandline import CommandLine, CommandMessage
 from bamboost_tui.screens.collection_picker import CollectionHit, CollectionPicker
-from bamboost_tui.utils import KeySubgroupsMixin, get_index
+from bamboost_tui.utils import KeySubgroupsMixin, get_index, variable_to_color
 from bamboost_tui.widgets import ModifiedDataTable, SortOrder
 from bamboost_tui.widgets.confirmation import ModalPrompt
 
@@ -128,12 +128,12 @@ class Placeholder(Static):
         with Center():
             yield Static(
                 dedent("""
-                            dP                           dP                                    dP  
-                            88                           88                                    88  
+                            dP                           dP                                    dP
+                            88                           88                                    88
                             88d888b. .d8888b. 88d8b.d8b. 88d888b. .d8888b. .d8888b. .d8888b. d8888P
-                            88'  `88 88'  `88 88'`88'`88 88'  `88 88'  `88 88'  `88 Y8ooooo.   88  
-                            88.  .88 88.  .88 88  88  88 88.  .88 88.  .88 88.  .88       88   88  
-                            88Y8888' `88888P8 dP  dP  dP 88Y8888' `88888P' `88888P' `88888P'   dP  
+                            88'  `88 88'  `88 88'`88'`88 88'  `88 88'  `88 88'  `88 Y8ooooo.   88
+                            88.  .88 88.  .88 88  88  88 88.  .88 88.  .88 88.  .88       88   88
+                            88Y8888' `88888P8 dP  dP  dP 88Y8888' `88888P' `88888P' `88888P'   dP
                         """),
                 classes="logo",
             )
@@ -435,7 +435,13 @@ class CollectionTable(ModifiedDataTable, KeySubgroupsMixin, inherit_bindings=Fal
 class ScreenCollection(Screen, inherit_bindings=False):
     BINDINGS = [
         Binding("ctrl+m", "toggle_picker", "toggle the collection picker"),
-        Binding("ctrl+t", "cycle_tabs", "cycle through tabs", show=False),
+        Binding(
+            "ctrl+t",
+            "cycle_tabs",
+            "cycle through tabs",
+            show=False,
+            id="collection.cycle_tabs",
+        ),
         Binding("q", "close", "close collection", show=False),
     ]
     BINDING_GROUP_TITLE = "Screen commands"

--- a/bamboost_tui/screens/collection.py
+++ b/bamboost_tui/screens/collection.py
@@ -24,8 +24,8 @@ from textual.widgets.data_table import ColumnKey
 from typing_extensions import Self
 
 from bamboost_tui.commandline import CommandLine, CommandMessage
-from bamboost_tui.screens.collection_picker import CollectionHit, CollectionPicker
-from bamboost_tui.utils import KeySubgroupsMixin, get_index, variable_to_color
+from bamboost_tui.screens.collection_palette import CollectionHit, CollectionPicker
+from bamboost_tui.utils import KeySubgroupsMixin, get_index
 from bamboost_tui.widgets import ModifiedDataTable, SortOrder
 from bamboost_tui.widgets.confirmation import ModalPrompt
 

--- a/bamboost_tui/screens/collection.py
+++ b/bamboost_tui/screens/collection.py
@@ -13,7 +13,6 @@ from rich.text import Text
 from textual import on, work
 from textual.binding import Binding
 from textual.color import Color
-from textual.command import Command, Hit
 from textual.containers import Center, Container, Horizontal, Right
 from textual.coordinate import Coordinate
 from textual.geometry import Offset, Region
@@ -215,9 +214,6 @@ class CollectionTable(ModifiedDataTable, KeySubgroupsMixin, inherit_bindings=Fal
     COMPONENT_CLASSES = DataTable.COMPONENT_CLASSES | {
         "datatable--label",
     }
-    HELP = """
-    Explore your simulations in this collection. Enter to view the respective HDF file.
-    """
     DEFAULT_CSS = """
     CollectionTable {
         layers: bottom top;

--- a/bamboost_tui/screens/collection_palette.py
+++ b/bamboost_tui/screens/collection_palette.py
@@ -1,34 +1,19 @@
 from __future__ import annotations
 
-from time import monotonic
 from typing import TYPE_CHECKING
 
 from rich.console import Group
 from rich.style import Style as RichStyle
 from rich.table import Column, Table
 from rich.text import Text
-from textual import work
 from textual._context import active_app
-from textual.app import ComposeResult
-from textual.binding import Binding
-from textual.command import (
-    Command,
-    CommandInput,
-    CommandList,
-    CommandPalette,
-    Hit,
-    Hits,
-    Matcher,
-    Provider,
-    SearchIcon,
-)
-from textual.containers import Horizontal, Vertical
+from textual.command import Hit, Hits, Matcher, Provider
 from textual.message import Message
 from textual.screen import Screen
 from textual.style import Style
 from textual.visual import VisualType
-from textual.widgets import Button, LoadingIndicator
-from textual.worker import get_current_worker
+
+from bamboost_tui.command_palette import CommandPalette
 
 if TYPE_CHECKING:
     from bamboost.index.sqlmodel import CollectionORM
@@ -135,8 +120,6 @@ class CollectionProvider(Provider):
 
 class RemoteCollectionProvider(CollectionProvider):
     async def startup(self) -> None:
-        from bamboost.index import Index
-
         app = active_app.get()
         self.styles["uid"] = app.screen.get_component_rich_style(
             "collection-list--uid", partial=True
@@ -165,10 +148,6 @@ class RemoteCollectionProvider(CollectionProvider):
 
 
 class CollectionPicker(CommandPalette):
-    BINDINGS = [
-        Binding("ctrl+n", "cursor_down", "move cursor down", show=False),
-        Binding("ctrl+p", "command_list('cursor_up')", "move cursor up", show=False),
-    ]
     COMPONENT_CLASSES = CommandPalette.COMPONENT_CLASSES | {
         "collection-list--uid",
         "collection-list--path",
@@ -177,92 +156,7 @@ class CollectionPicker(CommandPalette):
 
     def __init__(self):
         super().__init__(
-            providers=[CollectionProvider], placeholder="Search collections"
+            providers=[CollectionProvider],
+            placeholder="Search collections",
+            id="collection-picker",
         )
-
-    def compose(self) -> ComposeResult:
-        """Compose the command palette.
-
-        Returns:
-            The content of the screen.
-        """
-        with Vertical(id="--container"):
-            with Horizontal(id="--input") as container:
-                container.border_title = "Collection Picker"
-                yield SearchIcon()
-                yield CommandInput(placeholder=self._placeholder)
-                if not self.run_on_select:
-                    yield Button("\u25b6")
-            with Vertical(id="--results"):
-                yield CommandList()
-                yield LoadingIndicator()
-
-    @work(exclusive=True, group=CommandPalette._GATHER_COMMANDS_GROUP)
-    async def _gather_commands(self, search_value: str) -> None:
-        """Gather up all of the commands that match the search value.
-
-        Args:
-            search_value: The value to search for.
-        """
-        gathered_commands: list[Command] = []
-        command_list = self.query_one(CommandList)
-        if (
-            command_list.option_count == 1
-            and command_list.get_option_at_index(0).id == self._NO_MATCHES
-        ):
-            command_list.remove_option(self._NO_MATCHES)
-
-        command_id = 0
-        worker = get_current_worker()
-
-        # Reset busy mode.
-        self._show_busy = False
-        clear_current = True
-        last_update = monotonic()
-
-        # Kick off the search, grabbing the iterator.
-        search_routine = self._search_for(search_value)
-        search_results = search_routine.__aiter__()
-
-        # We're going to be doing the send/await dance in this code, so we
-        # need to grab the first yielded command to start things off.
-        try:
-            hit = await search_results.__anext__()
-        except StopAsyncIteration:
-            hit = None
-
-        while hit:
-            # NEEDED TO CHANGE THIS LINE. RENDER THE PROMPT DIRECTLY
-            prompt = hit.prompt
-
-            gathered_commands.append(Command(prompt, hit, id=str(command_id)))
-
-            if worker.is_cancelled:
-                break
-
-            now = monotonic()
-            if (now - last_update) > self._RESULT_BATCH_TIME:
-                self._refresh_command_list(
-                    command_list, gathered_commands, clear_current
-                )
-                clear_current = False
-                last_update = now
-
-            command_id += 1
-
-            try:
-                hit = await search_routine.asend(worker.is_cancelled)
-            except StopAsyncIteration:
-                break
-
-        if not worker.is_cancelled:
-            self._refresh_command_list(command_list, gathered_commands, clear_current)
-
-        # One way or another, we're not busy any more.
-        self._show_busy = False
-
-        if command_list.option_count == 0 and not worker.is_cancelled:
-            self._hit_count = 0
-            self._start_no_matches_countdown(search_value)
-
-        self.add_class("-ready")

--- a/bamboost_tui/screens/collection_picker.py
+++ b/bamboost_tui/screens/collection_picker.py
@@ -132,6 +132,7 @@ class CollectionProvider(Provider):
             # yield Hit(1.0, self._render(coll), self.app.pop_screen)
             yield CollectionHit(1.0, coll, self)
 
+
 class RemoteCollectionProvider(CollectionProvider):
     async def startup(self) -> None:
         from bamboost.index import Index
@@ -150,6 +151,7 @@ class RemoteCollectionProvider(CollectionProvider):
             "command-palette--help-text", partial=True
         )
         from bamboost.core.remote import Remote
+
         self.collections = Remote()
         widths = (0, 0, 0)
         for coll in self.collections:
@@ -160,6 +162,7 @@ class RemoteCollectionProvider(CollectionProvider):
                 )
             )
         self._widths = widths
+
 
 class CollectionPicker(CommandPalette):
     BINDINGS = [
@@ -173,7 +176,9 @@ class CollectionPicker(CommandPalette):
     }
 
     def __init__(self):
-        super().__init__(providers=[CollectionProvider], placeholder="Search collections")
+        super().__init__(
+            providers=[CollectionProvider], placeholder="Search collections"
+        )
 
     def compose(self) -> ComposeResult:
         """Compose the command palette.

--- a/bamboost_tui/screens/command_palette.py
+++ b/bamboost_tui/screens/command_palette.py
@@ -22,17 +22,18 @@ if TYPE_CHECKING:
 class CustomCommand:
     name: str
     command: Callable[[GlobalCommands], Any]
+    label: str
     help: Optional[str] = None
 
 
 _commands: list[CustomCommand] = []
 
 
-def _add_command(name: str, help: Optional[str] = None) -> Callable:
+def _add_command(name: str, label: str, help: Optional[str] = None) -> Callable:
     """Decorator to add a command to the command palette."""
 
     def decorator(method: Callable) -> Callable:
-        _commands.append(CustomCommand(name, method, help))
+        _commands.append(CustomCommand(name, method, label, help))
         return method
 
     return decorator
@@ -76,7 +77,9 @@ class GlobalCommands(Provider):
             )
 
     @_add_command(
-        "Scan for collections", "The config is based on the current working directory."
+        "scan_collections",
+        label="Scan for collections",
+        help="The config is based on the current working directory.",
     )
     def scan_collections(self) -> None:
         """Scan for collections."""

--- a/bamboost_tui/screens/hdfview.py
+++ b/bamboost_tui/screens/hdfview.py
@@ -290,14 +290,14 @@ class Navigation(
     NavigationStatic, KeySubgroupsMixin, can_focus=True, inherit_bindings=False
 ):
     BINDINGS = [
-        Binding("j,down", "cursor_down"),
-        Binding("k,up", "cursor_up"),
-        Binding("l,right,enter", "cursor_right", "Move into group"),
-        Binding("h,left,escape", "cursor_left", "Move out of group"),
-        Binding("g>g", "cursor_top", "Go to top"),
-        Binding("G", "cursor_bottom", "Go to bottom"),
-        Binding("ctrl+d", "page_down", "Scroll down"),
-        Binding("ctrl+u", "page_up", "Scroll up"),
+        Binding("j,down", "cursor_down", show=False),
+        Binding("k,up", "cursor_up", show=False),
+        Binding("l,right,enter", "cursor_right", "Move into group", show=False),
+        Binding("h,left,escape", "cursor_left", "Move out of group", show=False),
+        Binding("g>g", "cursor_top", "Go to top", show=False),
+        Binding("G", "cursor_bottom", "Go to bottom", show=False),
+        Binding("ctrl+d", "page_down", "Scroll down", show=False),
+        Binding("ctrl+u", "page_up", "Scroll up", show=False),
     ]
     BINDING_GROUP_TITLE = "Navigation Panel"
 

--- a/bamboost_tui/screens/keybind_palette.py
+++ b/bamboost_tui/screens/keybind_palette.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from rich.table import Column, Table
+from textual._context import active_app
+from textual.app import App
+from textual.binding import Binding
+from textual.command import Hit, Hits, Matcher, Provider
+from textual.screen import Screen
+from textual.visual import VisualType
+
+from bamboost_tui.command_palette import CommandPalette
+
+
+class KeyHit(Hit):
+    def __init__(
+        self,
+        score: float,
+        binding: Binding,
+        matcher: Matcher | None = None,
+    ) -> None:
+        app = active_app.get()
+        super().__init__(
+            score,
+            self._render(app, binding, matcher),
+            lambda b=binding: app.simulate_key(binding.key),
+        )
+
+    def _render(
+        self, app: App, binding: Binding, matcher: Matcher | None = None
+    ) -> VisualType:
+        from rich.text import Text
+
+        key_style = app.screen.get_component_rich_style(
+            "command-palette--key", partial=True
+        )
+        help_style = app.screen.get_component_rich_style(
+            "command-palette--help-text", partial=True
+        )
+
+        # Highlight description if matcher is provided
+        description = (
+            matcher.highlight(binding.description)
+            if matcher is not None
+            else Text(binding.description)
+        )
+        description = Text.from_markup(
+            " ".join(
+                (
+                    description.markup,
+                    Text(f"[{binding.id}]" if binding.id else "", help_style).markup,
+                )
+            )
+        )
+
+        key_text = Text(binding.key, style=key_style)
+
+        # Create a table with two columns: description (left), key (right)
+        table = Table.grid(
+            Column(ratio=2),
+            Column(ratio=1, justify="right"),
+            padding=(0, 2),
+            expand=True,
+            pad_edge=False,
+        )
+        table.add_row(description, key_text)
+        return table
+
+
+class BindingsProvider(Provider):
+    """A command provider that exposes all Bindings from the app, screen, and widgets."""
+
+    def get_all_bindings(self, screen: Screen):
+        return screen.active_bindings.values()
+
+    async def search(self, query: str) -> Hits:
+        matcher = self.matcher(query)
+        screen = self.app.screen_stack[-2]
+        for active_binding in self.get_all_bindings(screen):
+            binding = active_binding.binding
+            score = matcher.match(
+                binding.description + binding.key + (binding.id or "")
+            )
+            if score > 0:
+                yield KeyHit(score, binding, self.matcher(query))
+
+    async def discover(self) -> Hits:
+        screen = self.app.screen_stack[-2]
+        for active_binding in self.get_all_bindings(screen):
+            binding = active_binding.binding
+            yield KeyHit(1, binding)
+
+
+class KeybindPalette(CommandPalette):
+    COMPONENT_CLASSES = CommandPalette.COMPONENT_CLASSES | {
+        "command-palette--key",
+        "command-palette--help-text",
+    }
+    DEFAULT_CSS = """
+    KeybindPalette > .command-palette--key {
+        color: $accent;
+    }
+    KeybindPalette > .command-palette--help-text {
+    }
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            [BindingsProvider], placeholder="Find bindings", id="keybind-palette"
+        )

--- a/bamboost_tui/theme.py
+++ b/bamboost_tui/theme.py
@@ -1,0 +1,28 @@
+from textual.theme import BUILTIN_THEMES, Theme
+
+
+ANSI_THEME = Theme(
+    name="ansi",
+    primary="ansi_blue",
+    secondary="ansi_magenta",
+    accent="ansi_yellow",
+    foreground="ansi_bright_white",
+    background="ansi_default",
+    success="ansi_bright_green",
+    warning=BUILTIN_THEMES["textual-dark"].warning,
+    error="ansi_red",
+    surface="ansi_black",
+    panel="ansi_bright_black",
+    boost="ansi_bright_green",
+    dark=True,
+    variables={
+        "foreground-muted": "ansi_white",
+        "input-cursor-background": "ansi_black",
+        "input-cursor-foreground": "ansi_white",
+        "block-cursor-background": "ansi_black",
+        "block-cursor-foreground": "ansi_white",
+        "border": "ansi_bright_black",
+        "border-focus": "ansi_blue",
+        "footer-background": "ansi_black",
+    },
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ pythonPlatform = "Linux"
 typeCheckingMode = "basic"
 reportOptionalMemberAccess = false
 reportOptionalSubscript = false
+useLibraryCodeForTypes = true
 
 [tool.uv.sources]
 bamboost = { path = "../bamboost@next", editable = true }


### PR DESCRIPTION
Issue: don't remember keybind for a certain command

- adds a picker with all active bindings
- makes bindings remappable using bamboost.config ([tui.keys])