### PR TITLE
feat(table): add row selection

### DIFF
--- a/bamboost_tui/bamboost.tcss
+++ b/bamboost_tui/bamboost.tcss
@@ -567,3 +567,8 @@ CellContentScreen {
     }
 }
 
+Screen.visual-mode Footer {
+    background: $accent 30%;
+    color: $text;
+}
+

--- a/bamboost_tui/screens/collections/table.py
+++ b/bamboost_tui/screens/collections/table.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import subprocess
 from datetime import datetime
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING, Iterable, Self
 
 from bamboost import Simulation
 from bamboost.constants import UID_SEPARATOR
@@ -16,7 +16,6 @@ from textual.geometry import Offset, Region
 from textual.reactive import var
 from textual.widgets import DataTable
 from textual.widgets.data_table import ColumnKey
-from typing_extensions import Self
 
 from bamboost_tui.commandline import CommandLine, CommandMessage
 from bamboost_tui.config import config_tui
@@ -64,7 +63,7 @@ def cell_highlighter(cell: object) -> Text:
 
 
 class CollectionTable(ModifiedDataTable, KeySubgroupsMixin, inherit_bindings=False):
-    BINDINGS = [
+    BINDINGS = [  # noqa: RUF012
         # Navigation
         Binding("enter", "select_cursor", "show simulation", show=False),
         Binding("j,down", "cursor_down", "move cursor down", show=False),
@@ -80,6 +79,30 @@ class CollectionTable(ModifiedDataTable, KeySubgroupsMixin, inherit_bindings=Fal
         # Commands
         Binding(":", "command_line", "enter command mode", show=True),
         Binding("/", 'command_line("goto", "")', "jump to column", show=False),
+        Binding(
+            "space",
+            "toggle_selection",
+            "toggle selection",
+            show=False,
+            id="collection.toggle_select",
+        ),
+        Binding(
+            "v",
+            "toggle_visual_mode",
+            "visual mode",
+            show=False,
+            id="collection.visual_mode",
+        ),
+        Binding(
+            "escape",
+            "cancel_visual_mode",
+            "cancel visual mode",
+            show=False,
+            id="collection.cancel_visual",
+        ),
+        Binding(
+            "y", "copy_uids", "copy selected UIDs", show=True, id="collection.copy_uids"
+        ),
         Binding("r", "reload", "reload data", show=False, id="collection.reload"),
         Binding("s", "sort_column", "sort column", show=False, id="collection.sort"),
         Binding("d", "delete", "delete simulation", show=False, id="collection.delete"),
@@ -114,8 +137,16 @@ class CollectionTable(ModifiedDataTable, KeySubgroupsMixin, inherit_bindings=Fal
         "datatable--label",
     }
     DEFAULT_CSS = """
+    $row-selected-background: $accent 30%;
+    $row-selected-color: $accent;
+
     CollectionTable {
         layers: bottom top;
+    }
+    CollectionTable > .datatable--row-selected {
+        background: $row-selected-background;
+        color: $row-selected-color;
+        text-style: bold italic;
     }
     """
 
@@ -206,6 +237,14 @@ class CollectionTable(ModifiedDataTable, KeySubgroupsMixin, inherit_bindings=Fal
     def watch_cursor_coordinate(
         self, old_coordinate: Coordinate, new_coordinate: Coordinate
     ) -> None:
+        if self.visual_start_row is not None:
+            r_min = min(old_coordinate.row, new_coordinate.row)
+            r_max = max(old_coordinate.row, new_coordinate.row)
+            for r in range(r_min, r_max + 1):
+                self.refresh_row(r)
+            super().watch_cursor_coordinate(old_coordinate, new_coordinate)
+            return
+
         old_region = self._get_cell_region(old_coordinate)
         new_region = self._get_cell_region(new_coordinate)
 
@@ -228,9 +267,74 @@ class CollectionTable(ModifiedDataTable, KeySubgroupsMixin, inherit_bindings=Fal
         # TODO: This may be remmoved
         super().watch_cursor_coordinate(old_coordinate, new_coordinate)
 
+    def watch_visual_start_row(self, old: int | None, new: int | None) -> None:
+        if new is not None:
+            self.screen.add_class("visual-mode")
+        else:
+            self.screen.remove_class("visual-mode")
+
     # -------------------------------------------------------------------------
     # Actions
     # -------------------------------------------------------------------------
+    def action_toggle_selection(self) -> None:
+        if self.visual_start_row is not None:
+            start, end = sorted([self.visual_start_row, self.cursor_row])
+            for i in range(start, end + 1):
+                key = self._row_locations.get_key(i)
+                if key is not None:
+                    if key in self.selected_rows:
+                        self.selected_rows.remove(key)
+                    else:
+                        self.selected_rows.add(key)
+                    self.refresh_row(i)
+            self.visual_start_row = None
+            self._selection_update_count += 1
+            self.refresh()
+        else:
+            row_key = self._row_locations.get_key(self.cursor_row)
+            if row_key is not None:
+                if row_key in self.selected_rows:
+                    self.selected_rows.remove(row_key)
+                else:
+                    self.selected_rows.add(row_key)
+                self.refresh_row(self.cursor_row)
+            self.action_cursor_down()
+            self._selection_update_count += 1
+            self.refresh()
+
+    def action_toggle_visual_mode(self) -> None:
+        if self.visual_start_row is None:
+            self.visual_start_row = self.cursor_row
+            self.refresh_row(self.cursor_row)
+        else:
+            self._selection_update_count += 1
+            self.refresh_row(self.cursor_row)
+            self.visual_start_row = None
+
+    def action_cancel_visual_mode(self) -> None:
+        if self.visual_start_row is not None:
+            r_min = min(self.visual_start_row, self.cursor_row)
+            r_max = max(self.visual_start_row, self.cursor_row)
+            self.visual_start_row = None
+            self._selection_update_count += 1
+            for r in range(r_min, r_max + 1):
+                self.refresh_row(r)
+
+    def action_copy_uids(self) -> None:
+        if self.selected_rows:
+            target_keys = list(self.selected_rows)
+        else:
+            current_key = self._row_locations.get_key(self.cursor_row)
+            if current_key is None:
+                self.notify("No row selected", severity="warning")
+                return
+            target_keys = [current_key]
+
+        uids = [f"{self.uid}{UID_SEPARATOR}{key.value}" for key in target_keys]
+        text = "\n".join(uids)
+        self.app.copy_to_clipboard(text)
+        self.notify(f"Copied {len(uids)} UID(s) to clipboard")
+
     def action_sort_column(
         self, column_key: ColumnKey | str | None = None, reverse: bool | None = None
     ):

--- a/bamboost_tui/theme.py
+++ b/bamboost_tui/theme.py
@@ -24,5 +24,7 @@ ANSI_THEME = Theme(
         "border": "ansi_bright_black",
         "border-focus": "ansi_blue",
         "footer-background": "ansi_black",
+        "row-selected-background": "ansi_blue",
+        "row-selected-color": "ansi_bright_white",
     },
 )

--- a/bamboost_tui/widgets/_datatable.py
+++ b/bamboost_tui/widgets/_datatable.py
@@ -21,6 +21,7 @@ from rich.text import Text
 from textual._types import SegmentLines
 from textual.color import Color
 from textual.coordinate import Coordinate
+from textual.reactive import var
 from textual.renderables.styled import Styled
 from textual.widgets._data_table import (
     _EMPTY_TEXT,
@@ -49,6 +50,10 @@ class SortOrder(Enum):
 
 
 class ModifiedDataTable(DataTable):
+    COMPONENT_CLASSES = DataTable.COMPONENT_CLASSES | {"datatable--row-selected"}
+    visual_start_row: var[int | None] = var(None)
+    _selection_update_count: var[int] = var(0)
+
     def __init__(
         self,
         cell_highlighter: Callable[[object], Text] | None = None,
@@ -73,6 +78,7 @@ class ModifiedDataTable(DataTable):
         self._header_cell_render_cache = {}
         self._sort_column: ColumnKey | None = None
         self._sort_column_order = SortOrder.DESC
+        self.selected_rows: set[RowKey] = set()
 
         super().__init__(
             show_header=show_header,
@@ -91,6 +97,18 @@ class ModifiedDataTable(DataTable):
             classes=classes,
             disabled=disabled,
         )
+
+    def _invalidate_selection_caches(self) -> None:
+        self._row_render_cache.clear()
+        self._cell_render_cache.clear()
+
+    def _is_row_highlighted(self, row_index: int, row_key: RowKey) -> bool:
+        if row_key in self.selected_rows:
+            return True
+        if self.visual_start_row is not None:
+            start, end = sorted([self.visual_start_row, self.cursor_row])
+            return start <= row_index <= end
+        return False
 
     def _render_line_in_row(
         self,
@@ -128,6 +146,8 @@ class ModifiedDataTable(DataTable):
             self._show_hover_cursor,
             self._update_count,
             self._pseudo_class_state,
+            self._selection_update_count,
+            self.visual_start_row,
         )
 
         if cache_key in self._row_render_cache:
@@ -148,10 +168,16 @@ class ModifiedDataTable(DataTable):
         if self._labelled_row_exists and self.show_row_labels:
             # The width of the row label is updated again on idle
             cell_location = Coordinate(row_index, -1)
+            label_style = header_style
+            if self._is_row_highlighted(row_index, row_key):
+                selected_style = self.get_component_styles(
+                    "datatable--row-selected"
+                ).rich_style
+                label_style += selected_style
             label_cell_lines = render_cell(
                 row_index,
                 -1,
-                header_style,
+                label_style,
                 width=self._row_label_column_width,
                 cursor=should_highlight(cursor_location, cell_location, "row"),
                 hover=should_highlight(hover_location, cell_location, cursor_type),
@@ -164,6 +190,11 @@ class ModifiedDataTable(DataTable):
             else:
                 fixed_style = self.get_component_styles("datatable--fixed").rich_style
                 fixed_style += Style.from_meta({"fixed": True})
+                if self._is_row_highlighted(row_index, row_key):
+                    selected_style = self.get_component_styles(
+                        "datatable--row-selected"
+                    ).rich_style
+                    fixed_style += selected_style
             for column_index, column in enumerate(
                 self.ordered_columns[: self.fixed_columns]
             ):
@@ -179,6 +210,11 @@ class ModifiedDataTable(DataTable):
                 fixed_row.append(fixed_cell_lines)
 
         row_style = self._get_row_style(row_index, base_style)
+        if self._is_row_highlighted(row_index, row_key):
+            selected_style = self.get_component_styles(
+                "datatable--row-selected"
+            ).rich_style
+            row_style += selected_style
 
         scrollable_row = []
         for column_index, column in enumerate(self.ordered_columns):
@@ -319,7 +355,8 @@ class ModifiedDataTable(DataTable):
             self._show_hover_cursor,
             self._update_count,
             self._pseudo_class_state,
-        )  # pyright: ignore[reportAssignmentType]
+            self._selection_update_count,
+        )  # ty:ignore[invalid-assignment]
 
         if is_header_cell:
             if cell_cache_key in self._header_cell_render_cache:
@@ -328,7 +365,7 @@ class ModifiedDataTable(DataTable):
         if cell_cache_key in self._cell_render_cache and not is_header_cell:
             return self._cell_render_cache[cell_cache_key]
 
-        base_style += Style.from_meta({"row": row_index, "column": column_index})
+        style = base_style + Style.from_meta({"row": row_index, "column": column_index})
         row_label, row_cells = self._get_row_renderables(row_index)
 
         if is_row_label_cell:
@@ -379,7 +416,7 @@ class ModifiedDataTable(DataTable):
         lines = self.app.console.render_lines(
             Styled(
                 Padding(cell, (0, self.cell_padding)),
-                pre_style=base_style + component_style,
+                pre_style=style + component_style,
                 post_style=post_style,
             ),
             options,

--- a/bamboost_tui/widgets/_datatable.py
+++ b/bamboost_tui/widgets/_datatable.py
@@ -10,7 +10,7 @@ This implementation changes the following:
 from __future__ import annotations
 
 from enum import Enum
-from itertools import zip_longest
+from itertools import zip_longest, chain
 from typing import Callable, Literal, cast
 
 from rich.console import RenderableType
@@ -33,6 +33,8 @@ from textual.widgets._data_table import (
     RowRenderables,
     default_cell_formatter,
 )
+from textual.strip import Strip
+from textual._segment_tools import line_crop
 
 
 class SortOrder(Enum):
@@ -109,6 +111,65 @@ class ModifiedDataTable(DataTable):
             start, end = sorted([self.visual_start_row, self.cursor_row])
             return start <= row_index <= end
         return False
+    
+    def _render_line(self, y: int, x1: int, x2: int, base_style: Style) -> Strip:
+        """Render a (possibly cropped) line into a Strip (a list of segments
+            representing a horizontal line).
+
+        Args:
+            y: Y coordinate of line
+            x1: X start crop.
+            x2: X end crop (exclusive).
+            base_style: Style to apply to line.
+
+        Returns:
+            The Strip which represents this cropped line.
+        """
+
+        width = self.size.width
+
+        try:
+            row_key, y_offset_in_row = self._get_offsets(y)
+        except LookupError:
+            return Strip.blank(width, base_style)
+
+        cache_key = (
+            y,
+            x1,
+            x2,
+            width,
+            self.cursor_coordinate,
+            self.hover_coordinate,
+            base_style,
+            self.cursor_type,
+            self._show_hover_cursor,
+            self._update_count,
+            self._pseudo_class_state,
+            self._selection_update_count,
+        )
+        if cache_key in self._line_cache:
+            return self._line_cache[cache_key]
+
+        fixed, scrollable = self._render_line_in_row(
+            row_key,
+            y_offset_in_row,
+            base_style,
+            cursor_location=self.cursor_coordinate,
+            hover_location=self.hover_coordinate,
+        )
+        fixed_width = sum(
+            column.get_render_width(self)
+            for column in self.ordered_columns[: self.fixed_columns]
+        )
+
+        fixed_line: list[Segment] = list(chain.from_iterable(fixed)) if fixed else []
+        scrollable_line: list[Segment] = list(chain.from_iterable(scrollable))
+
+        segments = fixed_line + line_crop(scrollable_line, x1 + fixed_width, x2, width)
+        strip = Strip(segments).adjust_cell_length(width, base_style).simplify()
+
+        self._line_cache[cache_key] = strip
+        return strip
 
     def _render_line_in_row(
         self,
@@ -134,6 +195,7 @@ class ModifiedDataTable(DataTable):
         # cursor_type = self.cursor_type
         cursor_type = "row"
         show_cursor = self.show_cursor
+        is_selected = row_key in self.selected_rows
 
         cache_key = (
             row_key,
@@ -146,7 +208,7 @@ class ModifiedDataTable(DataTable):
             self._show_hover_cursor,
             self._update_count,
             self._pseudo_class_state,
-            self._selection_update_count,
+            is_selected,
             self.visual_start_row,
         )
 


### PR DESCRIPTION
still a bug: when selecting with <space> (single selection), the row/cell cache is wrong and one gets wrong highlighting if staying on the same column as the one that was used when selection was triggered. Only a visual artifact though.. Visual mode select works well.

@dbueeler 